### PR TITLE
Scrollify doesn't ignore currentHash anymore

### DIFF
--- a/jquery.scrollify.js
+++ b/jquery.scrollify.js
@@ -273,9 +273,9 @@
 				calculatePositions(false);
 
 
-				if(hasLocation===false && settings.sectionName) {
+				if(hasLocation===false && settings.sectionName && !currentHash) {
 					window.location.hash = names[0];
-				} else {
+				} else if (!currentHash) {
 					animateScroll(index);
 				}
 				


### PR DESCRIPTION
If you loaded your page with an hash to an existing ID, scrollify just ignored it and stopped the default browser behavior. 

For example, `mysite.com/#test` became `mysite.com/#home` (where `home is the first section)`.

Now it's fixed.