### PR TITLE
[WIP] Explicitly define dependencies through bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,5 +21,9 @@
     "bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "dependencies": {
+    "jquery": "~1.*",
+    "jquery.easing": "*",
+  }
 }


### PR DESCRIPTION
Scrollify requires both jquery and jquery.easing (I believe this one is also required, not only suggested).

I haven't tested the changes (yet). Don't know if this issue was already addressed.
