### PR TITLE
Default hash

### DIFF
--- a/jquery.scrollify.js
+++ b/jquery.scrollify.js
@@ -57,7 +57,7 @@
 			scrollbars: true,
 			axis:"y",
 			target:"html,body",
-			defaultHash:true,
+			defaultHash:true, 
 			before:function() {},
 			after:function() {},
 			afterResize:function() {}

--- a/jquery.scrollify.js
+++ b/jquery.scrollify.js
@@ -57,6 +57,7 @@
 			scrollbars: true,
 			axis:"y",
 			target:"html,body",
+			defaultHash:true,
 			before:function() {},
 			after:function() {},
 			afterResize:function() {}
@@ -69,6 +70,7 @@
 			settings.before(index,elements);
 			interstitialIndex = 1;
 			if(settings.sectionName) {
+				
 				window.location.hash = names[index];
 			}
 			if(instant) {
@@ -408,7 +410,10 @@
 
 
 		if(hasLocation===false && settings.sectionName) {
-			window.location.hash = names[0];
+			if (settings.defaultHash) {
+				window.location.hash = names[0];
+			}
+			
 		} else {
 			animateScroll(index,false);
 		}


### PR DESCRIPTION
It's awesome plugin, I used it on many sites. But most of the client not wish to have the hash tag on first page load. for example ```my-site.com/#home``` this is the first page load url, but clients not willing to have ```#home``` hash tag on first page load. So I added the option in the plugin called ```'defaultHash':true```. So users can easily decide hash tag should come on the first page load or not. 

I think it's useful to have this option. may be we need to change the name or something. Let me know what you think.