### PR TITLE
Fix broken bower install command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Scrollify appends a hash value to the URL for each section, this allows for perm
 ```
 ## Installation
 
--	[bower](http://bower.io/) - bower install scrollify
+-	[bower](http://bower.io/) - bower install Scrollify
 -	[npm](https://www.npmjs.com/) - npm install jquery-scrollify
 
 ## Behaviour


### PR DESCRIPTION
refer to this issue #93 
The command should be `bower install Scrollify` with capital **S**.