### PR TITLE
fix for URI change when <base> tag set

### DIFF
--- a/jquery.scrollify.js
+++ b/jquery.scrollify.js
@@ -122,7 +122,8 @@
 			if(settings.sectionName && !(firstLoad===true && index===0)) {
 				if(history.pushState) {
 				    try {
-							history.replaceState(null, null, names[index]);
+						var curURI = window.location.href.split(/[#]/)[0];
+						history.replaceState(null, null, curURI+names[index]);
 				    } catch (e) {
 				    	if(window.console) {
 				    		console.warn("Scrollify warning: This needs to be hosted on a server to manipulate the hash value.");


### PR DESCRIPTION
history.replaceState uses an incorrect path when sending in a null url param and using a base tag (https://bugs.chromium.org/p/chromium/issues/detail?id=279278)

To combat, fetch current window.location.href and remove any anchors already set - maybe ugly, but it fixed the issue for me...