### PR TITLE
Handle section names that are all numeric characters by forcing to String

### DIFF
--- a/jquery.scrollify.js
+++ b/jquery.scrollify.js
@@ -627,7 +627,7 @@
 						heights[i] = parseInt($this.offset().top);
 					}
 					if(settings.sectionName && $this.data(settings.sectionName)) {
-						names[i] = "#" + $this.data(settings.sectionName).replace(/ /g,"-");
+						names[i] = "#" + $this.data(settings.sectionName).toString().replace(/ /g,"-");
 					} else {
 						if($this.is(settings.interstitialSection)===false) {
 							names[i] = "#" + (i + 1);


### PR DESCRIPTION
If section name is all numeric, such as 1234567, the replace function will throw this error.

Uncaught TypeError: $(...).data(...).replace is not a function

Fixing by calling toString() before replace.