### PR TITLE
fix issue #161: before()/after() doesn't trigger

### DIFF
--- a/jquery.scrollify.js
+++ b/jquery.scrollify.js
@@ -173,6 +173,7 @@
 						console.warn("Scrollify warning:", window.location.hash, "is not a valid jQuery expression.");
 					}
 				}
+				currentIndex = index;
 				$(settings.target).promise().done(function(){
 					currentIndex = index;
 					locked = false;


### PR DESCRIPTION
animateScroll() called with different 'index' in a very short time, such as index 0, 1.
when index form 0 change to 1 then change 0，because of short time promise().done() not call, so currentIndex still 0. this time if (currentIndex === index) { callbacks = false; }

