### PR TITLE
Respecting standardScrollElements in the keyHandler.

### DIFF
--- a/jquery.scrollify.js
+++ b/jquery.scrollify.js
@@ -336,6 +336,10 @@ if touchScroll is false - update index
       keyHandler:function(e) {
         if(disabled===true || document.activeElement.readOnly===false) {
           return true;
+        } else if(settings.standardScrollElements) {
+          if($(e.target).is(settings.standardScrollElements) || $(e.target).closest(settings.standardScrollElements).length) {
+            return true;
+          }
         }
         if(locked===true) {
           return false;


### PR DESCRIPTION
The Up and Down arrows will trigger scrollify if you're currently in a standardScrollElement.  IE, a text area, or scrollable div (like quilljs.)

This PR simply copies the logic from the wheelHandler and touchHandler into the keyHandler.