### PR TITLE
WP Admin bar fix

### DIFF
--- a/jquery.scrollify.js
+++ b/jquery.scrollify.js
@@ -655,7 +655,11 @@ if touchScroll is false - update index
           if(i>0) {
             heights[i] = parseInt($this.offset().top) + settings.offset;
           } else {
-            heights[i] = parseInt($this.offset().top);
+            if($('body').hasClass('admin-bar')){
+              heights[i] = parseInt($this.offset().top-32);
+            }else{
+              heights[i] = parseInt($this.offset().top);
+            }
           }
           if(settings.sectionName && $this.data(settings.sectionName)) {
             names[i] = "#" + $this.data(settings.sectionName).toString().replace(/ /g,"-");


### PR DESCRIPTION
Update fixes height offset for WP admin menu when logged in. Checks for presence of the admin-bar class and if so, compensates for the height of 32px.