### PR TITLE
fix height on getportHeight to respect iOS different height in its menubars

### DIFF
--- a/jquery.scrollify.js
+++ b/jquery.scrollify.js
@@ -93,7 +93,7 @@ if touchScroll is false - update index
       afterRender:function() {}
     };
   function getportHeight() {
-    return ($window.height() + settings.offset);
+    return (window.innerHeight + settings.offset);
   }
   function animateScroll(index,instant,callbacks,toTop) {
     if(currentIndex===index) {


### PR DESCRIPTION
Here you go. Resolves https://github.com/lukehaas/Scrollify/issues/385.

A timely merge would be greatly appreciated.